### PR TITLE
Fix some of the inconsistencies in gnome 40

### DIFF
--- a/gnome-shell/_common.scss
+++ b/gnome-shell/_common.scss
@@ -1378,8 +1378,12 @@ StScrollBar {
 
 /* OVERVIEW */
 
-#overview {
-  spacing: 24px; //
+.controls-manager, .secondary-monitor-workspaces {
+  spacing: 24px;
+}
+
+#overviewGroup {
+  background-color: $_bubble_bg_color;
 }
 
 .overview-controls {
@@ -1477,7 +1481,6 @@ StScrollBar {
     color: $topbar_color;
     background-color: $topbar_bg_color;
     padding: 6px 0;
-    border: 1px solid $borders_color;
     border-left: 0px;
     border-radius: 0px 5px 5px 0px;
 
@@ -1497,9 +1500,9 @@ StScrollBar {
     }
 
   }
-
-  .dash-item-container > StWidget {
-    padding: 4px 8px;
+  
+  .dash-background {
+    background-color: darken($topbar_bg_color, 5);
   }
 
   .dash-label { //osd tooltip

--- a/gnome-shell/gnome-shell.css
+++ b/gnome-shell/gnome-shell.css
@@ -1236,8 +1236,11 @@ StScrollBar {
   spacing: 12px; }
 
 /* OVERVIEW */
-#overview {
+.controls-manager, .secondary-monitor-workspaces {
   spacing: 24px; }
+
+#overviewGroup {
+  background-color: rgba(40, 42, 54, 0.95); }
 
 .overview-controls {
   padding-bottom: 32px; }
@@ -1335,7 +1338,6 @@ StScrollBar {
   color: #f8f8f2;
   background-color: rgba(40, 42, 54, 0.95);
   padding: 6px 0;
-  border: 1px solid #21232d;
   border-left: 0px;
   border-radius: 0px 5px 5px 0px; }
   #dash:rtl {
@@ -1348,8 +1350,8 @@ StScrollBar {
     width: 24px;
     height: 24px; }
 
-.dash-item-container > StWidget {
-  padding: 4px 8px; }
+.dash-background {
+  background-color: rgba(29, 31, 39, 0.95); }
 
 .dash-label {
   border-radius: 7px;


### PR DESCRIPTION
An attempt at fixing the background color and the dash menu in gnome-shell v40. (#105) There are still quite a few new bugs which appeared after the update that I couldn't fix but this should at least fix the most obvious ones.

![before fix](https://i.imgur.com/VKWF2kq.jpg)
![after fix](https://i.imgur.com/0fby1Hp.jpg)