### PR TITLE
Xfce 4.16 improvement

### DIFF
--- a/gtk-3.20/apps/_thunar.scss
+++ b/gtk-3.20/apps/_thunar.scss
@@ -9,15 +9,18 @@
     -gtk-icon-transform:scale(0.72);
   }
   
-  scrolledwindow.sidebar treeview.view {
-    background: $base_color;
+  scrolledwindow.sidebar treeview.view, scrollbar.right {
+    background: $sidebar_bg_color;
     padding: 1.5px;
     border: none;
     box-shadow: none;
   }
-  
+
+  scrolledwindow.standard-view scrollbar.right{
+    background-color: $base_color;
+  }
   /* path-bar of thunar */
-  window.thunar toolbar#location-toolbar > toolitem > widget > widget.linked.path-bar > button.toggle.path-bar-button, window.thunar paned > scrolledwindow treeview.view {
+  window.thunar toolbar > toolitem > widget > widget.linked.path-bar > button.toggle.path-bar-button, window.thunar paned > scrolledwindow treeview.view {
     &:hover, &:checked, &:selected{ 
         background-color: transparent;
         color: $purple; 
@@ -29,7 +32,7 @@
     }
   }
   
-  window.thunar toolbar#location-toolbar > toolitem > widget > widget.linked.path-bar > button.path-bar-button {
+  window.thunar toolbar > toolitem > widget > widget.linked.path-bar > button.path-bar-button {
     background: none;
     outline: none;
     border: none;

--- a/gtk-3.20/apps/_xfce.scss
+++ b/gtk-3.20/apps/_xfce.scss
@@ -1,11 +1,14 @@
-.xfce4-panel.background {
-    background-color: $panel_bg_color;
-    color: $fg_color;
+.xfce4-panel
+    .background {
+        background-color: $panel_bg_color;
+        color: $fg_color;
 
-    text-shadow: none;
-    -gtk-icon-shadow: none;
+        text-shadow: none;
+        -gtk-icon-shadow: none;
 
-    button.flat { @extend %panelbutton; }
+        button.flat { @extend %panelbutton; }
+    }
+    #XfcePanelWindow, #XfcePanelWindow.marching-ants {transition: none;}
 }
 
 #tasklist-button {

--- a/gtk-3.20/apps/_xfce.scss
+++ b/gtk-3.20/apps/_xfce.scss
@@ -1,5 +1,5 @@
 .xfce4-panel
-    .background {
+    &.background {
         background-color: $panel_bg_color;
         color: $fg_color;
 
@@ -8,7 +8,7 @@
 
         button.flat { @extend %panelbutton; }
     }
-    #XfcePanelWindow, #XfcePanelWindow.marching-ants {transition: none;}
+    &#XfcePanelWindow, &#XfcePanelWindow.marching-ants {transition: none;}
 }
 
 #tasklist-button {

--- a/gtk-3.20/apps/_xfce.scss
+++ b/gtk-3.20/apps/_xfce.scss
@@ -1,4 +1,4 @@
-.xfce4-panel
+.xfce4-panel {
     &.background {
         background-color: $panel_bg_color;
         color: $fg_color;


### PR DESCRIPTION
this is xfce panel 4.16 every time after you exit xfce4-panel preference before `.xfce4-panel#XfcePanelWindow, .xfce4-panel#XfcePanelWindow.marching-ants {transition: none;}` added to scss
![image](https://user-images.githubusercontent.com/16707606/126306298-8dae4bdc-0e92-4fbe-a07d-d39eb7b346c4.png)

and this is thunar toolbar before and after `#location-toolbar` in `.thunar toolbar` removed
![thunar](https://user-images.githubusercontent.com/16707606/126307542-8526de90-99ca-443c-9e4a-6f95addd84c4.png)

the rest change is thunar sidebar color changed from `$base_color` to `$sidebar_color` and matching the scrollbar in sidebar and thunar main window

i only test this fix on xfce 4.16