### PR TITLE
Remove broken icon theme from install instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,19 +14,3 @@ gsettings set org.gnome.desktop.wm.preferences theme "Dracula"
 ```
 
 or Change via distribution specific tweak tool.
-
-## Icon Theme (optional)
-
-#### Install manually
-
-Download using the [GitHub .zip download](https://github.com/dracula/gtk/files/5214870/Dracula.zip) option and extract the `.zip` file to the icons directory i.e. `/usr/share/icons/` or `~/.icons/` (create it if necessary).
-
-#### Activating icon theme
-
-To activate the theme in Gnome, run the following commands in Terminal: 
-
-```
-gsettings set org.gnome.desktop.interface icon-theme "Dracula"
-```
-
-or Change via distribution specific tweak tool.


### PR DESCRIPTION
The icon theme linked in the install instructions is broken, as well as not being a part of the gtk repository (#142) and shouldn't
be linked to on the website. If the icon theme is to be included as part of the dracula project, it should be working and have an official repository, to allow contribution and development to occur.