### PR TITLE
Fix height of button on SDDM login

### DIFF
--- a/kde/sddm/Dracula/Login.qml
+++ b/kde/sddm/Dracula/Login.qml
@@ -125,7 +125,7 @@ SessionManagementScreen {
         background: Rectangle {
             id: buttonBackground
             width: parent.width
-            height: 30
+            height: parent.height
             radius: width / 2
             color: "#9B79CC"
             opacity: enabled ? 1.0 : 0.3


### PR DESCRIPTION
This change fixes an issue with the SDDM login screen. The background of the button was set to an absolute height of `30`, but the element itself was taller. As a result, there is an unequal amount of spacing between the top of the button and the bottom of the button, as can be seen in this screenshot prior to the final change (ignore that the button is max width, that was just me testing):

![image](https://user-images.githubusercontent.com/49003204/227794272-e0b60789-8250-4da1-b7cf-02be1663d8af.png)

I have changed the background to instead match the height of the parent element, which results in the text being correctly vertically aligned in the center of the button:

![image](https://user-images.githubusercontent.com/49003204/227794399-10c11bfa-cae1-4d58-a857-81365cdfa406.png)

_Apologies for the camera shots instead of screenshots, I didn't have a VM to make the changes in, I did it on my host machine_