### PR TITLE
Add Makefile for easier installation / uninstallation on KDE

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,6 +15,25 @@ gsettings set org.gnome.desktop.wm.preferences theme "Dracula"
 
 or Change via distribution specific tweak tool.
 
+
+### KDE
+
+### Install manually
+Pull the source code using git (or alternatively [Download the Latest ZIP File](https://github.com/dracula/gtk/archive/refs/heads/master.zip)):
+
+```bash
+git clone https://github.com/dracula/gtk.git
+```
+
+In a terminal, enter the directory containing the source code and run the `install` make target with the `PLATFORM` variable set to `KDE`:
+
+```bash
+cd gtk
+make install PLATFORM=KDE
+```
+
+After installation is complete, open the appearance settings and choose the Dracula theme in the `Global Theme` section.
+
 ## Icon Theme (optional)
 
 #### Install manually

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,10 +1,10 @@
-### [GTK](https://www.gtk.org/)
+## [GTK](https://www.gtk.org/)
 
-#### Install manually
+### Install manually
 
 Download using the [GitHub .zip download](https://github.com/dracula/gtk/archive/master.zip) option and extract the `.zip` file to the themes directory i.e. `/usr/share/themes/` or `~/.themes/` (create it if necessary).
 
-#### Activating theme
+### Activating theme
 
 To activate the theme in Gnome, run the following commands in Terminal:
 
@@ -16,7 +16,7 @@ gsettings set org.gnome.desktop.wm.preferences theme "Dracula"
 or Change via distribution specific tweak tool.
 
 
-### KDE
+## KDE
 
 ### Install manually
 Pull the source code using git (or alternatively [Download the Latest ZIP File](https://github.com/dracula/gtk/archive/refs/heads/master.zip)):
@@ -36,11 +36,11 @@ After installation is complete, open the appearance settings and choose the Drac
 
 ## Icon Theme (optional)
 
-#### Install manually
+### Install manually
 
 Download using the [GitHub .zip download](https://github.com/dracula/gtk/files/5214870/Dracula.zip) option and extract the `.zip` file to the icons directory i.e. `/usr/share/icons/` or `~/.icons/` (create it if necessary).
 
-#### Activating icon theme
+### Activating icon theme
 
 To activate the theme in Gnome, run the following commands in Terminal: 
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -34,6 +34,20 @@ make install PLATFORM=KDE
 
 After installation is complete, open the appearance settings and choose the Dracula theme in the `Global Theme` section.
 
+### Uninstall manually
+To uninstall the manually installed KDE theme, pull the source code using git (or alternatively [Download the Latest ZIP File](https://github.com/dracula/gtk/archive/refs/heads/master.zip)):
+
+```bash
+git clone https://github.com/dracula/gtk.git
+```
+
+In a terminal, enter the directory containing the source code and run the `clean` make target
+
+```bash
+cd gtk
+make clean
+```
+
 ## Icon Theme (optional)
 
 ### Install manually

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,48 @@
+ clean:
+	@echo "* Removing Plasma theme..."
+	rm -rf ~/.local/share/plasma/desktoptheme/Dracula
+	rm -rf ~/.local/share/plasma/desktoptheme/Dracula-Solid
+	rm -rf ~/.local/share/plasma/look-and-feel/Dracula
+
+	@echo "\n* Removing Aurorae theme..."
+	rm -rf ~/.local/share/aurorae/themes/Dracula
+
+	@echo "\n* Removing color schemes..."
+	rm -f ~/.local/share/color-schemes/Dracula.colors
+	rm -f ~/.local/share/color-schemes/DraculaPurple.colors
+
+	@echo "\n* Removing cursors..."
+	rm -rf ~/.icons/Dracula-cursors
+
+	@echo "\n* Removing SDDM theme (requires root)..."
+	sudo rm -rf /usr/share/sddm/themes/Dracula
+
+install:
+ifeq ($(filter $(PLATFORM),kde KDE),)
+	@echo "Exiting: only KDE is currently supported by the Makefile"
+	@exit 1
+endif
+	@echo "* Making required paths (requires root)..."
+	mkdir -p ~/.local/share/plasma/desktoptheme
+	mkdir -p ~/.local/share/plasma/look-and-feel
+	mkdir -p ~/.local/share/aurorae/themes
+	mkdir -p ~/.local/share/color-schemes
+	mkdir -p ~/.icons
+	sudo mkdir -p /usr/share/sddm/themes
+
+	@echo "\n* Installing Plasma theme..."
+	cp -r kde/plasma/desktoptheme/* ~/.local/share/plasma/desktoptheme/
+	cp -r kde/plasma/look-and-feel/* ~/.local/share/plasma/look-and-feel/
+
+	@echo "\n* Installing Aurorae theme..."
+	cp -r kde/aurorae/Dracula ~/.local/share/aurorae/themes/
+
+	@echo "\n* Installing color schemes..."
+	cp -r kde/color-schemes/* ~/.local/share/color-schemes/
+
+	@echo "\n* Installing cursors..."
+	cp -r kde/cursors/Dracula-cursors ~/.icons/
+
+	@echo "\n* Installing SDDM theme (requires root)..."
+	sudo cp -r kde/sddm/Dracula /usr/share/sddm/themes/
+


### PR DESCRIPTION
This PR adds a Makefile that can be used by KDE users to manually install or uninstall the theme. The KDE installation requires a number of steps, which new users to KDE may not be aware of, so I thought this would be a useful thing to add in.

The `install` target, as can be seen in the instructions I've added to `INSTALL.md` requires a `PLATFORM` variable to be set to ensure that users will not run this in other desktop environments and assume it is supported. The file could be updated in the future though to add support for automating installation for other environments too though.